### PR TITLE
Install collectd packages only when needed

### DIFF
--- a/keepalived/cluster.sls
+++ b/keepalived/cluster.sls
@@ -6,6 +6,12 @@ keepalived_packages:
   pkg.installed:
   - names: {{ cluster.pkgs }}
 
+{%- if pillar.collectd is defined %}
+keepalived_packages_for_collectd:
+  pkg.installed:
+  - names: {{ cluster.collectd_pkgs }}
+{%- endif %}
+
 keepalived_config:
   file.managed:
   - name: {{ cluster.config }}

--- a/keepalived/map.jinja
+++ b/keepalived/map.jinja
@@ -1,6 +1,7 @@
 {% set cluster = salt['grains.filter_by']({
     'Debian': {
-        'pkgs': ['keepalived', 'python-pyroute2'],
+        'pkgs': ['keepalived'],
+        'collectd_pkgs': ['python-pyroute2'],
         'service': 'keepalived',
         'config': '/etc/keepalived/keepalived.conf',
         'instance': {}


### PR DESCRIPTION
This change ensures that the python-pyroute2 package which is required
by collectd isn't installed if collectd itself isn't defined.